### PR TITLE
Document pagination options for /events/restSearch

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -1407,6 +1407,10 @@ https://<misp url>/events/restSearch/download/null/null/null/null/tag1&&tag2&&!t
 <dd>Include the attachments/encrypted samples in the export</dd>
 <dt>metadata</dt>
 <dd>Only fetch the event metadata (event data, tags, relations) and skip the attributes</dd>
+<dt>limit</dt>
+<dd>Limit the number of results returned; use together with page.</dd>
+<dt>page</dt>
+<dd>If a limit is set, sets the page to be returned, starting at 1; page 3, limit 100 will return records 201->300). When requesting a page beyond the number of available pages, the returned results list will be empty.</dd>
 </dl>
 
 The keywords false or null should be used for optional empty parameters in the URL.


### PR DESCRIPTION
Document pagination options for `/events/restSearch`, since they are crucial for exporting larger data sets successfully and with reasonable performance.

Reference: https://github.com/MISP/MISP/issues/2426#issuecomment-431657077

The documentation of the APIs is still somewhat confusing and might benefit from a more thorough rewrite by somebody more familiar with the APIs than me.