### PR TITLE
chg: [faq] Add FAQ question on setting baseurl via CLI

### DIFF
--- a/faq/README.md
+++ b/faq/README.md
@@ -315,7 +315,15 @@ You can reset the password via the console.
 See [Issue #1160](https://github.com/MISP/MISP/issues/1160)
 
 `/var/www/MISP/app/Console/cake Password [email] [password]`
+### How do I set the baseurl from the command line?
 
+You can change the baseurl via the console. 
+
+    sudo -u www-data /var/www/MISP/app/Console/cake Baseurl [baseurl]
+    
+You can confirm the baseurl is updated correctly by checking the config.php file
+
+    grep baseurl /var/www/MISP/app/Config/config.php
 ***
 ## Usage questions
 ### How can I see all the deleted events in a MISP instance?


### PR DESCRIPTION
See issue https://github.com/MISP/misp-book/issues/196

I realize this will probably be somewhat duplicate info after fixing https://github.com/MISP/misp-book/issues/195 but I think people might go to the FAQ page first and it does seem to be a somewhat frequent question as there was also mention of it in https://github.com/MISP/misp-book/issues/204.