### PR TITLE
chg: Point to the new default main branch for MISP related repositories

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -55,7 +55,7 @@ To get started with MISP we advise to enable the CIRCL OSINT feed within your MI
 [More](http://www.misp-project.org/feeds/)
 
 ## MISP format
-MISP formats are described in specification document based on the current implementation of MISP core and PyMISP. These specifications are available for other developers willing to develop their own tools or software supporting the [MISP format](https://github.com/MISP/misp-rfc/blob/master/misp-core-format/raw.md.txt).
+MISP formats are described in specification document based on the current implementation of MISP core and PyMISP. These specifications are available for other developers willing to develop their own tools or software supporting the [MISP format](https://github.com/MISP/misp-rfc/blob/main/misp-core-format/raw.md.txt).
 
 ## MISP Galaxy Cluster
 MISP galaxy is a simple method to express a large object called cluster that can be attached to MISP events or attributes. A cluster can be composed of one or more elements. Elements are expressed as key-values. There are default vocabularies available in MISP galaxy but those can be overwritten, replaced or updated as you wish. Existing clusters and vocabularies can be used as-is or as a template. MISP distribution can be applied to each cluster to permit a limited or broader distribution scheme. The following document is generated from the machine-readable JSON describing the MISP galaxy.

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -13,16 +13,16 @@ In the next screenshot you see a bad practice example. The tlp:white tag is adde
 ![Screenshot of event tagged with tlp:white and tlp:white tag set at attribute level - bad practice](./figures/bad-practice-tagging.png)
 ### Minimal subset of tags to use for each event
 #### Traffic Light Protocol
-[TLP-Tags](https://github.com/MISP/misp-taxonomies/blob/master/tlp/machinetag.json): TLP utilizes a simple four color schema for indicating how intelligence can be shared.
+[TLP-Tags](https://github.com/MISP/misp-taxonomies/blob/main/tlp/machinetag.json): TLP utilizes a simple four color schema for indicating how intelligence can be shared.
 
 #### Confidence
-[Confidence-Tags/Vetting State](https://github.com/MISP/misp-taxonomies/blob/master/cssa/machinetag.json): There are huge differences in the quality of data, whether it was vetted upon sharing. As this means that the author was confident that the shared data is or at least was a good indicator of compromise.
+[Confidence-Tags/Vetting State](https://github.com/MISP/misp-taxonomies/blob/main/cssa/machinetag.json): There are huge differences in the quality of data, whether it was vetted upon sharing. As this means that the author was confident that the shared data is or at least was a good indicator of compromise.
 
 #### Origin
-[Origin-Tags](https://github.com/MISP/misp-taxonomies/blob/master/cssa/machinetag.json): Describes where the information came from, whether it was in an automated fashion or in a manual investigation. This should give an impression how value this intelligence is, as manual investigation should supersede any automatic generation of data.
+[Origin-Tags](https://github.com/MISP/misp-taxonomies/blob/main/cssa/machinetag.json): Describes where the information came from, whether it was in an automated fashion or in a manual investigation. This should give an impression how value this intelligence is, as manual investigation should supersede any automatic generation of data.
 
 #### Permissible Actions Protocol
-[PAP-Tags](https://github.com/MISP/misp-taxonomies/blob/master/PAP/machinetag.json): An even more advanced approach of data classification is using the Permissible Actions Protocol. It indicates how the received data can be used to search for compromises within the individual company or constituency.
+[PAP-Tags](https://github.com/MISP/misp-taxonomies/blob/main/PAP/machinetag.json): An even more advanced approach of data classification is using the Permissible Actions Protocol. It indicates how the received data can be used to search for compromises within the individual company or constituency.
 ## Setting distribution
 Similar to tagging, inheritance should be used wherever possible. This is especially important when using sharing groups due to limit the impact of sharing group usage on performance. Note that for distribution, the event or object distribution of the attribute should be the same or less restrictive than the attribute distribution. Below are two good practice examples, the first using community distribution and the second using sharing groups. Note that a combination of the two can be used as well.
 

--- a/faq/README.md
+++ b/faq/README.md
@@ -21,7 +21,7 @@ If you want to discuss something related to MISP or want help from the MISP comm
 
 From a hardware perspective, MISP's requirements are quite humble, a web server with 2+ cores and 8-16 GB of memory should be plenty, though more is always better of course. A lot of it depends on the data set and the number of users you are dealing with. 
 
-We recommend a standard LAMP stack on top of Ubuntu >18.04 LTS. For details on the exact dependencies please refer to the [installation guide](https://misp.github.io/MISP/INSTALL.ubuntu1804/) as well as the [requirements for the MISP modules](https://github.com/MISP/misp-modules/blob/master/REQUIREMENTS). 
+We recommend a standard LAMP stack on top of Ubuntu >18.04 LTS. For details on the exact dependencies please refer to the [installation guide](https://misp.github.io/MISP/INSTALL.ubuntu1804/) as well as the [requirements for the MISP modules](https://github.com/MISP/misp-modules/blob/main/REQUIREMENTS). 
 
 During a [Hackathon](https://hackathon.hack.lu) a small tool called [MISP-Sizer](https://misp-project.org/MISP-sizer/) was conceived. It will give you a **very rough** idea on what requirements are if you have a bigger installation. [source-code is here](https://github.com/MISP/MISP-sizer)
 

--- a/galaxy/README.md
+++ b/galaxy/README.md
@@ -828,98 +828,98 @@ Clicking on the addition symbol on the left of Beijing Group extends the module.
 
 #### Clusters
 
-[Android](https://github.com/MISP/misp-galaxy/blob/master/clusters/android.json) - Android malware galaxy based on multiple open sources.
+[Android](https://github.com/MISP/misp-galaxy/blob/main/clusters/android.json) - Android malware galaxy based on multiple open sources.
 
-[Backdoor](https://github.com/MISP/misp-galaxy/blob/master/clusters/backdoor.json) - A list of backdoor malware.
+[Backdoor](https://github.com/MISP/misp-galaxy/blob/main/clusters/backdoor.json) - A list of backdoor malware.
 
-[Banker](https://github.com/MISP/misp-galaxy/blob/master/clusters/banker.json) - A list of banker malware.
+[Banker](https://github.com/MISP/misp-galaxy/blob/main/clusters/banker.json) - A list of banker malware.
 
-[Botnet](https://github.com/MISP/misp-galaxy/blob/master/clusters/botnet.json) - botnet galaxy
+[Botnet](https://github.com/MISP/misp-galaxy/blob/main/clusters/botnet.json) - botnet galaxy
 
-[Branded vulnerability](https://github.com/MISP/misp-galaxy/blob/master/clusters/branded_vulnerability.json) - List of known vulnerabilities and attacks with a branding
+[Branded vulnerability](https://github.com/MISP/misp-galaxy/blob/main/clusters/branded_vulnerability.json) - List of known vulnerabilities and attacks with a branding
 
-[Cert eu govsector](https://github.com/MISP/misp-galaxy/blob/master/clusters/cert-eu-govsector.json) - Cert EU GovSector
+[Cert eu govsector](https://github.com/MISP/misp-galaxy/blob/main/clusters/cert-eu-govsector.json) - Cert EU GovSector
 
-[Exploit kit](https://github.com/MISP/misp-galaxy/blob/master/clusters/exploit-kit.json) - Exploit-Kit is an enumeration of some exploitation kits used by adversaries. The list includes document, browser and router exploit kits.It's not meant to be totally exhaustive but aim at covering the most seen in the past 5 years
+[Exploit kit](https://github.com/MISP/misp-galaxy/blob/main/clusters/exploit-kit.json) - Exploit-Kit is an enumeration of some exploitation kits used by adversaries. The list includes document, browser and router exploit kits.It's not meant to be totally exhaustive but aim at covering the most seen in the past 5 years
 
-[Malpedia](https://github.com/MISP/misp-galaxy/blob/master/clusters/malpedia.json) - Malware galaxy cluster based on Malpedia.
+[Malpedia](https://github.com/MISP/misp-galaxy/blob/main/clusters/malpedia.json) - Malware galaxy cluster based on Malpedia.
 
-[Microsoft activity group](https://github.com/MISP/misp-galaxy/blob/master/clusters/microsoft-activity-group.json) - Activity groups as described by Microsoft
+[Microsoft activity group](https://github.com/MISP/misp-galaxy/blob/main/clusters/microsoft-activity-group.json) - Activity groups as described by Microsoft
 
-[Mitre attack pattern](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-attack-pattern.json) - ATT&CK tactic
+[Mitre attack pattern](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-attack-pattern.json) - ATT&CK tactic
 
-[Mitre course of action](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-course-of-action.json) - ATT&CK Mitigation
+[Mitre course of action](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-course-of-action.json) - ATT&CK Mitigation
 
-[Mitre enterprise attack attack pattern](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-enterprise-attack-attack-pattern.json) - ATT&CK tactic
+[Mitre enterprise attack attack pattern](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-enterprise-attack-attack-pattern.json) - ATT&CK tactic
 
-[Mitre enterprise attack course of action](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-enterprise-attack-course-of-action.json) - ATT&CK Mitigation
+[Mitre enterprise attack course of action](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-enterprise-attack-course-of-action.json) - ATT&CK Mitigation
 
-[Mitre enterprise attack intrusion set](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-enterprise-attack-intrusion-set.json) - Name of ATT&CK Group
+[Mitre enterprise attack intrusion set](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-enterprise-attack-intrusion-set.json) - Name of ATT&CK Group
 
-[Mitre enterprise attack malware](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-enterprise-attack-malware.json) - Name of ATT&CK software
+[Mitre enterprise attack malware](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-enterprise-attack-malware.json) - Name of ATT&CK software
 
-[Mitre enterprise attack tool](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-enterprise-attack-tool.json) - Name of ATT&CK software
+[Mitre enterprise attack tool](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-enterprise-attack-tool.json) - Name of ATT&CK software
 
-[Mitre intrusion set](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-intrusion-set.json) - Name of ATT&CK Group
+[Mitre intrusion set](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-intrusion-set.json) - Name of ATT&CK Group
 
-[Mitre malware](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-malware.json) - Name of ATT&CK software
+[Mitre malware](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-malware.json) - Name of ATT&CK software
 
-[Mitre mobile attack attack pattern](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-mobile-attack-attack-pattern.json) - ATT&CK tactic
+[Mitre mobile attack attack pattern](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-mobile-attack-attack-pattern.json) - ATT&CK tactic
 
-[Mitre mobile attack course of action](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-mobile-attack-course-of-action.json) - ATT&CK Mitigation
+[Mitre mobile attack course of action](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-mobile-attack-course-of-action.json) - ATT&CK Mitigation
 
-[Mitre mobile attack intrusion set](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-mobile-attack-intrusion-set.json) - Name of ATT&CK Group
+[Mitre mobile attack intrusion set](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-mobile-attack-intrusion-set.json) - Name of ATT&CK Group
 
-[Mitre mobile attack malware](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-mobile-attack-malware.json) - Name of ATT&CK software
+[Mitre mobile attack malware](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-mobile-attack-malware.json) - Name of ATT&CK software
 
-[Mitre mobile attack tool](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-mobile-attack-tool.json) - Name of ATT&CK software
+[Mitre mobile attack tool](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-mobile-attack-tool.json) - Name of ATT&CK software
 
-[Mitre pre attack attack pattern](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-pre-attack-attack-pattern.json) - ATT&CK tactic
+[Mitre pre attack attack pattern](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-pre-attack-attack-pattern.json) - ATT&CK tactic
 
-[Mitre pre attack intrusion set](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-pre-attack-intrusion-set.json) - Name of ATT&CK Group
+[Mitre pre attack intrusion set](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-pre-attack-intrusion-set.json) - Name of ATT&CK Group
 
-[Mitre tool](https://github.com/MISP/misp-galaxy/blob/master/clusters/mitre-tool.json) - Name of ATT&CK software
+[Mitre tool](https://github.com/MISP/misp-galaxy/blob/main/clusters/mitre-tool.json) - Name of ATT&CK software
 
-[Preventive measure](https://github.com/MISP/misp-galaxy/blob/master/clusters/preventive-measure.json) - Preventive measures based on the ransomware document overview as published in https://docs.google.com/spreadsheets/d/1TWS238xacAto-fLKh1n5uTsdijWdCEsGIM0Y0Hvmc5g/pubhtml# . The preventive measures are quite generic and can fit any standard Windows infrastructure and their security measures.
+[Preventive measure](https://github.com/MISP/misp-galaxy/blob/main/clusters/preventive-measure.json) - Preventive measures based on the ransomware document overview as published in https://docs.google.com/spreadsheets/d/1TWS238xacAto-fLKh1n5uTsdijWdCEsGIM0Y0Hvmc5g/pubhtml# . The preventive measures are quite generic and can fit any standard Windows infrastructure and their security measures.
 
-[Ransomware](https://github.com/MISP/misp-galaxy/blob/master/clusters/ransomware.json) - Ransomware galaxy based on https://docs.google.com/spreadsheets/d/1TWS238xacAto-fLKh1n5uTsdijWdCEsGIM0Y0Hvmc5g/pubhtml and http://pastebin.com/raw/GHgpWjar
+[Ransomware](https://github.com/MISP/misp-galaxy/blob/main/clusters/ransomware.json) - Ransomware galaxy based on https://docs.google.com/spreadsheets/d/1TWS238xacAto-fLKh1n5uTsdijWdCEsGIM0Y0Hvmc5g/pubhtml and http://pastebin.com/raw/GHgpWjar
 
-[Rat](https://github.com/MISP/misp-galaxy/blob/master/clusters/rat.json) - remote administration tool or remote access tool (RAT), also called sometimes remote access trojan, is a piece of software or programming that allows a remote "operator" to control a system as if they have physical access to that system.
+[Rat](https://github.com/MISP/misp-galaxy/blob/main/clusters/rat.json) - remote administration tool or remote access tool (RAT), also called sometimes remote access trojan, is a piece of software or programming that allows a remote "operator" to control a system as if they have physical access to that system.
 
-[Sector](https://github.com/MISP/misp-galaxy/blob/master/clusters/sector.json) - Activity sectors
+[Sector](https://github.com/MISP/misp-galaxy/blob/main/clusters/sector.json) - Activity sectors
 
-[Stealer](https://github.com/MISP/misp-galaxy/blob/master/clusters/stealer.json) - A list of malware stealer.
+[Stealer](https://github.com/MISP/misp-galaxy/blob/main/clusters/stealer.json) - A list of malware stealer.
 
-[Tds](https://github.com/MISP/misp-galaxy/blob/master/clusters/tds.json) - TDS is a list of Traffic Direction System used by adversaries
+[Tds](https://github.com/MISP/misp-galaxy/blob/main/clusters/tds.json) - TDS is a list of Traffic Direction System used by adversaries
 
-[Threat actor](https://github.com/MISP/misp-galaxy/blob/master/clusters/threat-actor.json) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign.
+[Threat actor](https://github.com/MISP/misp-galaxy/blob/main/clusters/threat-actor.json) - Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign.
 
-[Tool](https://github.com/MISP/misp-galaxy/blob/master/clusters/tool.json) - threat-actor-tools is an enumeration of tools used by adversaries. The list includes malware but also common software regularly used by the adversaries.
+[Tool](https://github.com/MISP/misp-galaxy/blob/main/clusters/tool.json) - threat-actor-tools is an enumeration of tools used by adversaries. The list includes malware but also common software regularly used by the adversaries.
 
 #### Vocabularies
 
 ##### Common
 
-[Certainty level](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/common/certainty-level.json) - Certainty level of an associated element or cluster.
+[Certainty level](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/common/certainty-level.json) - Certainty level of an associated element or cluster.
 
-[Sector](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/common/sector.json) - List of activity sectors
+[Sector](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/common/sector.json) - List of activity sectors
 
-[Threat actor type](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/common/threat-actor-type.json) - threat actor type vocab as defined by Cert EU.
+[Threat actor type](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/common/threat-actor-type.json) - threat actor type vocab as defined by Cert EU.
 
-[Ttp category](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/common/ttp-category.json) - ttp category vocab as defined by Cert EU.
+[Ttp category](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/common/ttp-category.json) - ttp category vocab as defined by Cert EU.
 
-[Ttp type](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/common/ttp-type.json) - ttp type vocab as defined by Cert EU.
+[Ttp type](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/common/ttp-type.json) - ttp type vocab as defined by Cert EU.
 
 ##### threat-actor
 
-[Cert eu motive](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/threat-actor/cert-eu-motive.json) - Motive vocab as defined by Cert EU.
+[Cert eu motive](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/threat-actor/cert-eu-motive.json) - Motive vocab as defined by Cert EU.
 
-[Intended effect](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/threat-actor/intended-effect.json) - The IntendedEffectVocab is the default STIX vocabulary for expressing the intended effect of a threat actor
+[Intended effect](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/threat-actor/intended-effect.json) - The IntendedEffectVocab is the default STIX vocabulary for expressing the intended effect of a threat actor
 
-[Motivation](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/threat-actor/motivation.json) - The MotivationVocab is the default STIX vocabulary for expressing the motivation of a threat actor.
+[Motivation](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/threat-actor/motivation.json) - The MotivationVocab is the default STIX vocabulary for expressing the motivation of a threat actor.
 
-[Planning and operational support](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/threat-actor/planning-and-operational-support.json) - The PlanningAndOperationalSupportVocab is the default STIX vocabulary for expressing the planning and operational support functions available to a threat actor.
+[Planning and operational support](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/threat-actor/planning-and-operational-support.json) - The PlanningAndOperationalSupportVocab is the default STIX vocabulary for expressing the planning and operational support functions available to a threat actor.
 
-[Sophistication](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/threat-actor/sophistication.json) - The ThreatActorSophisticationVocab enumeration is used to define the default STIX vocabulary for expressing the subjective level of sophistication of a threat actor.
+[Sophistication](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/threat-actor/sophistication.json) - The ThreatActorSophisticationVocab enumeration is used to define the default STIX vocabulary for expressing the subjective level of sophistication of a threat actor.
 
-[Type](https://github.com/MISP/misp-galaxy/blob/master/vocabularies/threat-actor/type.json) - The ThreatActorTypeVocab enumeration is used to define the default STIX vocabulary for expressing the subjective type of a threat actor.
+[Type](https://github.com/MISP/misp-galaxy/blob/main/vocabularies/threat-actor/type.json) - The ThreatActorTypeVocab enumeration is used to define the default STIX vocabulary for expressing the subjective type of a threat actor.

--- a/misp-objects/README.md
+++ b/misp-objects/README.md
@@ -27,7 +27,7 @@ After pressing "Submit, you are given the possibility to review your object befo
 
 ## Creating object
 
-An object is designed using a JSON file which should respect a format described in [this document](https://github.com/MISP/misp-objects/blob/master/schema_objects.json).
+An object is designed using a JSON file which should respect a format described in [this document](https://github.com/MISP/misp-objects/blob/main/schema_objects.json).
 
 An object is basically a combination of two or more attributes that can be used together to represent real cyber security use-cases. These attributes are listed in a JSON object.
 

--- a/taxonomy/README.md
+++ b/taxonomy/README.md
@@ -184,7 +184,7 @@ Applying rules for distribution based on tags:
 
 ### MISP Taxonomies - tools
 
-- [machinetag.py](https://github.com/MISP/misp-taxonomies/blob/master/tools/machinetag.py) is a parsing tool to dump taxonomies expressed in Machine Tags (Triple Tags) and list all valid tags from a specific taxonomy.
+- [machinetag.py](https://github.com/MISP/misp-taxonomies/blob/main/tools/machinetag.py) is a parsing tool to dump taxonomies expressed in Machine Tags (Triple Tags) and list all valid tags from a specific taxonomy.
 
 ~~~~shell
 % cd tools


### PR DESCRIPTION
FYI:
https://github.com/MISP/misp-compliance seems to still be using master as default branch. Just letting you know in case you wanted to change all and it was overlooked.