### PR TITLE
[users:totp_delete] fix documentation to specify that both site admin…

### DIFF
--- a/administration/README.md
+++ b/administration/README.md
@@ -892,7 +892,7 @@ If you do not have them installed yet, you can run the equivalent of the below c
 You can see which users have TOTP/HOTP configured in the users index:
 ![Screenshot of users index page, with highlight showing the column which indicates a user has TOTP/HOTP configured](./figures/user-with-totp-active-in-users-index.png)
 
-As a site-admin (users can't do this themselves), you can delete TOTP/HOTP for a user from the view user page, by clicking the TOTP Delete button.
+As a site admin or org admin (users can't do this themselves), you can delete TOTP/HOTP for a user from the view user page, by clicking the TOTP Delete button.
 ![Screenshot of view user page with highlighted delete OTP button](./figures/delete-totp-button.png)
 
 ### Mandating TOTP/HOTP usage

--- a/using-the-system/README.md
+++ b/using-the-system/README.md
@@ -692,6 +692,6 @@ After setting up TOTP/HOTP for your account, you will be prompted for an OTP on 
 ![Screenshot of page requesting you to enter OTP after login](./figures/login-otp-request.png)
 Enter either a generated TOTP from your authenticator software, or the specified (numbered) paper based token.
 #### Deleting and re-generating TOTP/HOTP tokens
-Deletion of the TOTP/HOTP setup for your user can only be done by a site admin, reach out to the site admins of your instance in case you want to set up new tokens.
+Deletion of the TOTP/HOTP setup for your user can only be done by site admins and organisation admins. Reach out to your org admin (preferred), or alternatively to a site admin of your instance, in case you want to set up new tokens.
 #### Combining multiple forms of multi-factor authentication
 It is currently not possible to combine multiple forms of multi-factor authentication. As an example: once your user has TOTP/HOTP assigned, you can't use e-mail OTP for it. If you are using a system which has e-mail OTP set up as well, e-mail OTP will be used again when your TOTP/HOTP setup is deleted.


### PR DESCRIPTION
…s and org admins can delete totp for users

Please note this relates to https://github.com/MISP/MISP/pull/9301 , and somewhat requires for that PR to be merged at the same time or before.